### PR TITLE
Changes to align with tutorial

### DIFF
--- a/runtime/src/verifiablecreds.rs
+++ b/runtime/src/verifiablecreds.rs
@@ -33,8 +33,10 @@ decl_event!(
     where
         AccountId = <T as system::Trait>::AccountId,
     {
-        // A credential is issued - holder, cred, issuer
+        // A credential is issued - holder, subj, issuer
         CredentialIssued(AccountId, u32, AccountId),
+        // A credential is revoked - holder, subj, issuer
+        CredentialRevoked(AccountId, u32, AccountId),
         // A new subject is created.
         SubjectCreated(AccountId, u32),
     }
@@ -79,6 +81,7 @@ decl_module! {
             ensure!(<Credentials<T>>::exists((to.clone(), subject)), "Credential not issued yet.");
 
             <Credentials<T>>::remove((to.clone(), subject));
+            Self::deposit_event(RawEvent::CredentialRevoked(to, subject, sender));
         }
 
         /// Verify a credential.

--- a/runtime/src/verifiablecreds.rs
+++ b/runtime/src/verifiablecreds.rs
@@ -1,6 +1,7 @@
 use support::{decl_event, decl_module, decl_storage, StorageMap, StorageValue, ensure};
 use system::ensure_signed;
 use parity_codec::{Decode, Encode};
+use core::u32::MAX as MAX_SUBJECT;
 
 pub trait Trait: system::Trait + timestamp::Trait {
     type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
@@ -98,6 +99,8 @@ decl_module! {
         pub fn create_subject(origin) {
             let sender = ensure_signed(origin)?;
             let subject_count = <SubjectCount<T>>::get();
+
+            ensure!(subject_count < MAX_SUBJECT, "Max issuance count reached");
 
             <Subjects<T>>::insert(subject_count, sender.clone());
 

--- a/runtime/src/verifiablecreds.rs
+++ b/runtime/src/verifiablecreds.rs
@@ -20,7 +20,7 @@ decl_storage! {
         SubjectNonce get(subject_nonce) config(): u32;
         // Issuers can issue credentials to others.
         // Issuer to Subject mapping.
-        Issuers get(issuers) config(): map T::AccountId => u32;
+        Subjects get(subjects) config(): map u32 => T::AccountId;
         // Credentials store.
         // Mapping (holder, subject) to Credential.
         Credentials get(credentials): map (T::AccountId, u32) => Credential<T::Moment, T::AccountId>;
@@ -51,8 +51,8 @@ decl_module! {
             // Issue the credential - add to storage.
 
             let sender = ensure_signed(origin)?;
-            let issuer_subject = Self::issuers(sender.clone());
-            ensure!(issuer_subject == subject, "Unauthorized.");
+            let subject_issuer = Self::subjects(subject);
+            ensure!(subject_issuer == sender, "Unauthorized.");
 
             let now = <timestamp::Module<T>>::get();
             let cred = Credential {
@@ -74,8 +74,8 @@ decl_module! {
             // Change the bool flag of the stored credential tuple to false.
 
             let sender = ensure_signed(origin)?;
-            let issuer_subject = Self::issuers(sender.clone());
-            ensure!(issuer_subject == subject, "Unauthorized.");
+            let subject_issuer = Self::subjects(subject);
+            ensure!(subject_issuer == sender, "Unauthorized.");
             ensure!(<Credentials<T>>::exists((to.clone(), subject)), "Credential not issued yet.");
 
             <Credentials<T>>::remove((to.clone(), subject));
@@ -94,8 +94,7 @@ decl_module! {
             let sender = ensure_signed(origin)?;
             let subject_nonce = <SubjectNonce<T>>::get();
 
-            // Rewrites if the mapping already exists.
-            <Issuers<T>>::insert(sender.clone(), subject_nonce);
+            <Subjects<T>>::insert(subject_nonce, sender.clone());
 
             // Update the subject nonce.
             <SubjectNonce<T>>::put(subject_nonce + 1);

--- a/runtime/src/verifiablecreds.rs
+++ b/runtime/src/verifiablecreds.rs
@@ -19,7 +19,7 @@ pub struct Credential<Timestamp, AccountId> {
 decl_storage! {
     trait Store for Module<T: Trait> as VerifiableCreds {
         // global nonce for subject count
-        SubjectNonce get(subject_nonce) config(): Subject;
+        SubjectCount get(subject_count) config(): Subject;
         // Issuers can issue credentials to others.
         // Issuer to Subject mapping.
         Subjects get(subjects) config(): map Subject => T::AccountId;
@@ -97,15 +97,15 @@ decl_module! {
         /// Create a new subject.
         pub fn create_subject(origin) {
             let sender = ensure_signed(origin)?;
-            let subject_nonce = <SubjectNonce<T>>::get();
+            let subject_count = <SubjectCount<T>>::get();
 
-            <Subjects<T>>::insert(subject_nonce, sender.clone());
+            <Subjects<T>>::insert(subject_count, sender.clone());
 
             // Update the subject nonce.
-            <SubjectNonce<T>>::put(subject_nonce + 1);
+            <SubjectCount<T>>::put(subject_count + 1);
 
             // Deposit the event.
-            Self::deposit_event(RawEvent::SubjectCreated(sender, subject_nonce));
+            Self::deposit_event(RawEvent::SubjectCreated(sender, subject_count));
         }
     }
 }
@@ -163,7 +163,7 @@ mod tests {
     t.extend(
       GenesisConfig::<Test> {
         issuers: vec![(1, 1), (2, 2)],
-        subject_nonce: 3,
+        subject_count: 3,
       }
       .build_storage()
       .unwrap()


### PR DESCRIPTION
minor changes to align the code to the tutorial:

- map subject->account rather than the other way around
- ensure subject count can't overflow
- rename nonce to count
- issue event on revokation, too
- add `Subject` type alias for readibility 